### PR TITLE
scrub URL errors with heroku/x/scrub

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -3,9 +3,11 @@ package lnroll
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/apg/ln"
+	"github.com/heroku/x/scrub"
 	"github.com/pkg/errors"
 )
 
@@ -19,6 +21,19 @@ type Client interface {
 // grab a list of pointers to all of the functions in the callstack
 type stackTracer interface {
 	StackTrace() errors.StackTrace
+}
+
+func stripURLError(e error) error {
+	switch e.(type) {
+	case *url.Error:
+		ue := e.(*url.Error)
+		u, _ := url.Parse(ue.URL)
+		ue.URL = scrub.URL(u).String()
+
+		return ue
+	}
+
+	return e
 }
 
 // New returns a new FilterFunc which reports errors to Rollbar.
@@ -37,7 +52,7 @@ func New(client Client) ln.FilterFunc {
 				if e, ok := v.(error); !ok {
 					err = errors.New(toString(v))
 				} else {
-					err = e
+					err = stripURLError(e)
 				}
 			} else {
 				extras[k] = toString(v)

--- a/filter_test.go
+++ b/filter_test.go
@@ -3,6 +3,8 @@ package lnroll
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/apg/ln"
@@ -102,5 +104,38 @@ func TestFilterWithStack(t *testing.T) {
 	log.Critical(ctx, ln.F{"err": err})
 	if m.CS == 0 {
 		t.Errorf("Filter didn't fire on Critical %+v", *m)
+	}
+}
+
+func TestStripURLError(t *testing.T) {
+	cases := []struct {
+		name         string
+		err          error
+		secretToFind string
+	}{
+		{
+			name: "passthru",
+			err:  errors.New("test"),
+		},
+		{
+			name: "scrub secrets",
+			err: &url.Error{
+				Op:  "pan gangnam style",
+				URL: "http://AzureDiamond:hunter2@127.0.0.1/",
+				Err: errors.New("test"),
+			},
+		},
+	}
+
+	for _, cs := range cases {
+		t.Run(cs.name, func(t *testing.T) {
+			res := stripURLError(cs.err)
+			if cs.secretToFind != "" {
+				es := res.Error()
+				if strings.Contains(es, cs.secretToFind) {
+					t.Fatal("stripURLError didn't strip the password: %v", es)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Prevents credential leaks to rollbar by removing them from URL's.